### PR TITLE
Add `into_vec` method

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -105,6 +105,14 @@ impl<'a> Image<'a> {
         }
     }
 
+    #[inline(always)]
+    pub fn into_vec(self) -> Vec<u8> {
+        match self.pixels {
+            PixelsContainer::MutU8(p) => p.into(),
+            PixelsContainer::VecU8(v) => v,
+        }
+    }
+
     /// Mutable buffer with image pixels.
     #[inline(always)]
     fn buffer_mut(&mut self) -> &mut [u8] {


### PR DESCRIPTION
Thanks for the good crate.
I added this method because I want to retrieve the internal `Vec` without copying memory.
How do you like it?