### PR TITLE
make buffer_mut public

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -118,7 +118,7 @@ impl<'a> Image<'a> {
 
     /// Mutable buffer with image pixels.
     #[inline(always)]
-    fn buffer_mut(&mut self) -> &mut [u8] {
+    pub fn buffer_mut(&mut self) -> &mut [u8] {
         match &mut self.buffer {
             BufferContainer::MutU8(p) => p,
             BufferContainer::VecU8(ref mut v) => v.as_mut_slice(),


### PR DESCRIPTION
Make `Image::buffer_mut` `pub` to support https://github.com/Cykooz/fast_image_resize/issues/13

This is such a low level library I don't think it would be bad to be public,