### PR TITLE
cleanup: use (read|write)_unaligned for unaligned pointers

### DIFF
--- a/src/convolution/vertical_u8/avx2.rs
+++ b/src/convolution/vertical_u8/avx2.rs
@@ -220,7 +220,7 @@ unsafe fn vert_convolution_into_one_row_u8<T>(
 
         sss = _mm_packs_epi32(sss, sss);
         let dst_ptr = dst_chunk.as_mut_ptr() as *mut i32;
-        *dst_ptr = _mm_cvtsi128_si32(_mm_packus_epi16(sss, sss));
+        dst_ptr.write_unaligned(_mm_cvtsi128_si32(_mm_packus_epi16(sss, sss)));
 
         src_x += 4;
     }

--- a/src/convolution/vertical_u8/native.rs
+++ b/src/convolution/vertical_u8/native.rs
@@ -46,7 +46,7 @@ pub(crate) fn vert_convolution<T>(
                 let src_ptr = src_row.as_ptr() as *const u8;
                 let src_chunk = unsafe {
                     let ptr = src_ptr.add(x_src) as *const u32;
-                    *ptr
+                    ptr.read_unaligned()
                 };
 
                 let components: [u8; 4] = src_chunk.to_le_bytes();

--- a/src/convolution/vertical_u8/sse4.rs
+++ b/src/convolution/vertical_u8/sse4.rs
@@ -250,7 +250,7 @@ unsafe fn vert_convolution_into_one_row_u8<T: PixelExt<Component = u8>>(
 
         sss = _mm_packs_epi32(sss, sss);
         let dst_ptr = dst_chunk.as_mut_ptr() as *mut i32;
-        *dst_ptr = _mm_cvtsi128_si32(_mm_packus_epi16(sss, sss));
+        dst_ptr.write_unaligned(_mm_cvtsi128_si32(_mm_packus_epi16(sss, sss)));
 
         src_x += 4;
     }

--- a/src/simd_utils.rs
+++ b/src/simd_utils.rs
@@ -47,31 +47,31 @@ pub unsafe fn mm_cvtepu8_epi32_u8x3(buf: &[U8x3], index: usize) -> __m128i {
 #[inline(always)]
 pub unsafe fn mm_cvtepu8_epi32_from_u8(buf: &[u8], index: usize) -> __m128i {
     let ptr = buf.get_unchecked(index..).as_ptr() as *const i32;
-    _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*ptr))
+    _mm_cvtepu8_epi32(_mm_cvtsi32_si128(ptr.read_unaligned()))
 }
 
 #[inline(always)]
 pub unsafe fn mm_cvtsi32_si128_from_u8(buf: &[u8], index: usize) -> __m128i {
     let ptr = buf.get_unchecked(index..).as_ptr() as *const i32;
-    _mm_cvtsi32_si128(*ptr)
+    _mm_cvtsi32_si128(ptr.read_unaligned())
 }
 
 #[inline(always)]
 pub unsafe fn ptr_i16_to_set1_epi32(buf: &[i16], index: usize) -> __m128i {
-    _mm_set1_epi32(*(buf.get_unchecked(index..).as_ptr() as *const i32))
+    _mm_set1_epi32((buf.get_unchecked(index..).as_ptr() as *const i32).read_unaligned())
 }
 
 #[inline(always)]
 pub unsafe fn ptr_i16_to_256set1_epi32(buf: &[i16], index: usize) -> __m256i {
-    _mm256_set1_epi32(*(buf.get_unchecked(index..).as_ptr() as *const i32))
+    _mm256_set1_epi32((buf.get_unchecked(index..).as_ptr() as *const i32).read_unaligned())
 }
 
 #[inline(always)]
 pub unsafe fn ptr_i16_to_set1_epi64x(buf: &[i16], index: usize) -> __m128i {
-    _mm_set1_epi64x(*(buf.get_unchecked(index..).as_ptr() as *const i64))
+    _mm_set1_epi64x((buf.get_unchecked(index..).as_ptr() as *const i64).read_unaligned())
 }
 
 #[inline(always)]
 pub unsafe fn ptr_i16_to_256set1_epi64x(buf: &[i16], index: usize) -> __m256i {
-    _mm256_set1_epi64x(*(buf.get_unchecked(index..).as_ptr() as *const i64))
+    _mm256_set1_epi64x((buf.get_unchecked(index..).as_ptr() as *const i64).read_unaligned())
 }


### PR DESCRIPTION
This was caught by a recent change to Rust (22a7a19f9333bc1fcba97ce444a3515cb5fb33e6) which proactively detects dereferences of unaligned pointers. Switching from a dereference to the unaligned read and write methods fixes all the tests on today's nightly.

Fixes #15.