### PR TITLE
Do not pull in all of `image` dependencies when it's enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2.19"
 thiserror = "1.0"
 document-features = "0.2.10"
 # Optional dependencies
-image = { version = "0.25.1", optional = true }
+image = { version = "0.25.1", optional = true, default-features = false }
 bytemuck = { version = "1.16", optional = true }
 
 [features]


### PR DESCRIPTION
Add `default-features=false` to `image` dependency so that pulling in `image` does not automatically enable *all* the default formats and also rayon for `image` crate.

Without this change `image` pulls in a very large amount of dependencies.