### PR TITLE
Add bytemuck feature and derive some bytemuck traits for Pixel type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ rayon = { version = "1.11", optional = true }
 ## [DynamicImage](https://docs.rs/image/latest/image/enum.DynamicImage.html)
 ## type from the `image` crate.
 image = ["dep:image", "dep:bytemuck"]
+## Enable this feature to implement traits [bytemuck::Pod] and
+## [bytemuck::Zeroable] for `Pixel` type.
+bytemuck = ["dep:bytemuck"]
 ## This feature enables image processing in the ` rayon ` thread pool.
 rayon = ["dep:rayon", "resize/rayon", "image/rayon"]
 for_testing = ["image", "image/png"]

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -208,6 +208,25 @@ where
     }
 }
 
+// SAFETY: bytemuck derives are tripped by the use of generic arguments.
+// However, since Pixel<T, _, _> is repr(C) it introduces no padding after T nor
+// imposes any additional limitations on T.  Hence, if T is Zeroable, Pixel is
+// Zeroable.
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: bytemuck::Zeroable, C, const COUNT_OF_COMPONENTS: usize>
+    bytemuck::Zeroable for Pixel<T, C, COUNT_OF_COMPONENTS>
+where
+    T: Sized + Copy + Clone + PartialEq + Default + 'static,
+    C: PixelComponent {}
+
+// SAFETY: As above.  If T is Pod than Pixel<T> is Pod.
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: bytemuck::Pod, C, const COUNT_OF_COMPONENTS: usize>
+    bytemuck::Pod for Pixel<T, C, COUNT_OF_COMPONENTS>
+where
+    T: Sized + Copy + Clone + PartialEq + Default + 'static,
+    C: PixelComponent {}
+
 macro_rules! pixel_struct {
     ($name:ident, $type:tt, $comp_type:tt, $comp_count:literal, $pixel_type:expr, $doc:expr) => {
         #[doc = $doc]


### PR DESCRIPTION
Derive bytemuck::{Pod,Zeroable} traits for Pixel type when the new bytemuck feature is enabled.  With those traits, it’s possible to safely cast (through the use of bytemuck::cast family of functions) between different pixel representations.

For example, &[u32] can be safely converted into &[U8x4] to use with TypedImageRef::from_pixels_slice and thus eliminating the InvalidBufferAlignment error at compile time.

Note that use of bytemuck could eliminate unsafe blocks in align_buffer_to and align_buffer_to_mut functions but such change would require propagating T: bytemuck::Pod constraint which would be API breaking.